### PR TITLE
Add `rehype-inline-svg` and `rehype-toc` to plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,8 @@ collective.
 * [rehype-document](https://github.com/rehypejs/rehype-document) - Wrap a fragment in a document.
 * [rehype-highlight](https://github.com/rehypejs/rehype-highlight) - Highlight code blocks with [lowlight](https://github.com/wooorm/lowlight) (Highlight.js).
 * [rehype-prism](https://github.com/mapbox/rehype-prism) - Highlight code blocks with [refractor](https://github.com/wooorm/refractor) (Prism).
+* [rehype-inline-svg](https://github.com/JS-DevTools/rehype-inline-svg) - Inlines and optimizes SVG images
+* [rehype-toc](https://github.com/JS-DevTools/rehype-toc) - Adds a table of contents (TOC) to the page
 
 [Find more plugins »](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins)
 


### PR DESCRIPTION
Added two additional plugins to the list of plugins

* [rehype-inline-svg](https://github.com/JS-DevTools/rehype-inline-svg) - Inlines and optimizes SVG images
* [rehype-toc](https://github.com/JS-DevTools/rehype-toc) - Adds a table of contents (TOC) to the page
